### PR TITLE
Fix typos in urls

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -77,7 +77,7 @@
       <div class="footer">
         <div class="content">
           <p>
-            Beyond Transparency &mdash;  2013 <a href="http://codeforeamerica.org" target="_blank">Code for America</a>
+            Beyond Transparency &mdash;  2013 <a href="http://codeforamerica.org" target="_blank">Code for America</a>
           </p>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@ The rise of open data in the public sector has sparked innovation, driven effici
       </div>
       <div class="quote">
         <p>This book is  a resource for (and by) practitioners inside and outside government—from the municipal chief information officer to the community organizer to the civic-minded entrepreneur. <em>Beyond Transparency</em> is intended to capture and distill the community's learnings around open data for the past four years. And we know that the community is going to continue learning. That's why, in addition to the print version of the book which you can <a href="http://www.amazon.com/Beyond-Transparency-Future-Civic-Innovation/dp/0615889085/" target="_blank">order on Amazon</a>, we've also published the digital version of this book on this site under a Creative Commons license. The full text of this site is on GitHub — which means that anyone can submit a pull request with a suggested edit. Help us improve this resource for the community and write the next edition of <em>Beyond Transparency</em> by <a href="https://github.com/codeforamerica/beyondtransparency" target="_blank">submitting your pull requests.</a></p>
-     <p><a href="http://codeforeamerica.org" target="_blank">Code for America</a> is a national nonprofit committed to building a government for the people, by the people, that works in the 21st century. Over the past four years, CfA has worked with dozens of cities to support civic innovation through open data. You can support this work by <a href="https://github.com/codeforamerica/beyondtransparency" target="_blank">contributing to the book on GitHub</a>, <a href="http://brigade.codeforamerica.org">joining the CfA volunteer community</a> (the Brigade), <a href="https://secure.codeforamerica.org/page/contribute/default">donating to Code for America</a>, or <a href="http://www.codeforamerica.org/cities/" target="_blank">connecting your city</a> with CfA.</p>
+     <p><a href="http://codeforamerica.org" target="_blank">Code for America</a> is a national nonprofit committed to building a government for the people, by the people, that works in the 21st century. Over the past four years, CfA has worked with dozens of cities to support civic innovation through open data. You can support this work by <a href="https://github.com/codeforamerica/beyondtransparency" target="_blank">contributing to the book on GitHub</a>, <a href="http://brigade.codeforamerica.org">joining the CfA volunteer community</a> (the Brigade), <a href="https://secure.codeforamerica.org/page/contribute/default">donating to Code for America</a>, or <a href="http://www.codeforamerica.org/cities/" target="_blank">connecting your city</a> with CfA.</p>
 
      <div class="email">
        <h3>Interested in more about open data and Code for America?</h3>
@@ -153,7 +153,7 @@ The rise of open data in the public sector has sparked innovation, driven effici
 <div class="footer">
   <div class="content">
     <p>
-      Beyond Transparency &mdash;  2013 <a href="http://codeforeamerica.org" target="_blank">Code for America</a>
+      Beyond Transparency &mdash;  2013 <a href="http://codeforamerica.org" target="_blank">Code for America</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
Just some simple typos that needed fixing ( "codeforeamerica" >
"codeforamerica")
